### PR TITLE
Feat/add crash bang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2025-10-01
+
+### Added
+- **`crash!/1` function** - New "bang" version that uses `:kill` signal for guaranteed process termination
+  - Works with processes that have `Process.flag(:trap_exit, true)`
+  - Cannot be trapped by the target process
+  - Particularly useful for testing GenServers with cleanup logic in `handle_info({:EXIT, ...})`
+  - Supports both PID and registered name with automatic PID tracking
+  - Complete test suite including `TrapExitServer` demonstration
+
+### Changed
+- Updated module documentation to explain the difference between `crash/1` and `crash!/1`
+- Enhanced README with "When to use `crash!/1`?" section and practical examples
+- Added comparison table between `:shutdown` and `:kill` exit signals
+
+### Technical Details
+- `:kill` exit signal bypasses process trapping mechanisms
+- Maintains same API signature as `crash/1` for consistency
+- Includes integration tests with supervised trap_exit processes
+
 ## [0.1.0] - 2025-01-03
 
 ### Core Functions
@@ -48,4 +68,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Issue and PR templates for community contributions
 - Comprehensive test coverage with realistic usage examples
 
+[0.2.0]: https://github.com/volcov/let_it_crash/releases/tag/v0.2.0
 [0.1.0]: https://github.com/volcov/let_it_crash/releases/tag/v0.1.0

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule LetItCrash.MixProject do
   use Mix.Project
 
-  @version "0.1.0"
+  @version "0.2.0"
   @source_url "https://github.com/volcov/let_it_crash"
 
   def project do


### PR DESCRIPTION
# Pull Request

## Description

Adds `crash!/1` function that uses the `:kill` signal to guarantee process termination even when processes have `Process.flag(:trap_exit, true)`.

During OTP application testing, we discovered that `crash/1` doesn't work properly with processes that trap exits (common in GenServers that perform cleanup). The new `crash!/1` function solves this problem by using `:kill`, which cannot be trapped.

**Key changes:**
- ✨ New `crash!/1` function with untrappable `:kill` signal
- 🧪 Complete test suite with `TrapExitServer` demonstration
- 📚 Updated documentation (moduledoc, docstrings, README)
- 📝 Updated CHANGELOG with version 0.2.0 details
- 🔖 Package version updated from 0.1.0 → 0.2.0

## Type of Change

Mark the type of change this PR represents:

- [ ] 🐛 Bug fix (change that fixes an issue)
- [x] ✨ New feature (change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation (documentation-only changes)
- [ ] 🧹 Refactoring (code changes that neither fix bugs nor add features)
- [ ] ⚡ Performance (changes that improve performance)
- [x] 🧪 Tests (adding or correcting tests)

## How to Test

Run the tests to validate the new functionality:

```bash
# Run all tests (20 tests, 0 failures)
mix test

# Test specifically the new crash!/1 functionality
mix test test/let_it_crash_test.exs:96

# Verify compilation without warnings
mix compile --warnings-as-errors

# Generate updated documentation
mix docs
```

**Specific tests added:**
- `test "kills a process with trap_exit by PID"`
- `test "kills a registered process with trap_exit by name"`
- `test "crash! guarantees termination unlike normal exits"`
- `test "returns error for non-existent process"`
- `test "works with supervised trap_exit process"`

## Checklist

- [x] My code follows the project's style guide
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md (if applicable)

## Related Issues

Addresses the issue discovered during `ScoreCoordinator` testing where processes with `trap_exit: true` were not being terminated by `crash/1`.

## Comparison: `crash/1` vs `crash!/1`

| Function | Exit Signal | Can be Trapped? | Recommended Use |
|----------|-------------|-----------------|-----------------|
| `crash/1` | `:shutdown` | ✅ Yes (with `trap_exit`) | Normal processes |
| `crash!/1` | `:kill` | ❌ No | Processes with `trap_exit: true` |

## Example Usage

```elixir
defmodule ScoreCoordinator do
  use GenServer

  def init(_) do
    Process.flag(:trap_exit, true)  # Traps normal exits
    {:ok, %{}}
  end

  def handle_info({:EXIT, _pid, _reason}, state) do
    # Cleanup logic here
    {:noreply, state}
  end
end

# In tests:
test "coordinator recovers from forced crash" do
  {:ok, supervisor} = MySupervisor.start_link()
  {:ok, _pid} = MySupervisor.start_coordinator(supervisor, :coordinator)
  
  # ✅ Use crash! to guarantee termination
  LetItCrash.crash!(:coordinator)
  
  assert LetItCrash.recovered?(:coordinator)
end
```

## Additional Notes

- **Backward Compatible**: The existing `crash/1` function remains unchanged, maintaining full compatibility
- **Consistent API**: `crash!/1` follows the same signature as `crash/1` (PID or atom)
- **Automatic Tracking**: Both functions use the same ETS tracking system
- **Complete Documentation**: ExDoc, README, and CHANGELOG updated
- **Zero Warnings**: Credo passed with 0 issues, no compilation warnings
- **Semantic Versioning**: MINOR bump (0.1.0 → 0.2.0) - new feature, no breaking changes

---

**Ready for review and merge!** 🚀
