### PR TITLE
chore: replace crash! with crash/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2025-10-21
+
+### Changed (Breaking)
+- **Refactored `crash` API** - Following Elixir best practices, removed `crash!/1` function in favor of `crash/2`
+  - `crash!/1` has been removed (the `!` suffix is conventionally reserved for functions that raise exceptions)
+  - New signature: `crash(process, type \\ :shutdown)` where `type` can be `:shutdown` or `:kill`
+  - Follows the same convention as `Process.exit/2` with the process as the first argument
+  - Enables easy piping: `Process.whereis(:name) |> LetItCrash.crash(:kill)`
+  - `crash(pid)` - default behavior (`:shutdown` signal)
+  - `crash(pid, :kill)` - guarantees termination (cannot be trapped)
+  - Maintains support for both PID and registered name with automatic PID tracking
+  - Tests updated to use the new API
+
+### Migration Guide
+- Replace `crash!(process)` with `crash(process, :kill)`
+- `crash(process)` continues to work the same way (uses `:shutdown` by default)
+- Argument order follows `Process.exit/2`: process first, type second
+
 ## [0.2.0] - 2025-10-01
 
 ### Added
-- **`crash!/1` function** - New "bang" version that uses `:kill` signal for guaranteed process termination
+- **`crash!/1` function** - "Bang" version that uses `:kill` signal for guaranteed process termination
   - Works with processes that have `Process.flag(:trap_exit, true)`
   - Cannot be trapped by the target process
   - Particularly useful for testing GenServers with cleanup logic in `handle_info({:EXIT, ...})`
@@ -68,5 +86,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Issue and PR templates for community contributions
 - Comprehensive test coverage with realistic usage examples
 
+[0.3.0]: https://github.com/volcov/let_it_crash/releases/tag/v0.3.0
 [0.2.0]: https://github.com/volcov/let_it_crash/releases/tag/v0.2.0
 [0.1.0]: https://github.com/volcov/let_it_crash/releases/tag/v0.1.0

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule LetItCrash.MixProject do
   use Mix.Project
 
-  @version "0.2.0"
+  @version "0.3.0"
   @source_url "https://github.com/volcov/let_it_crash"
 
   def project do


### PR DESCRIPTION
# Pull Request

## Description

Refactors the `crash` API to follow Elixir conventions by removing `crash!/1` and introducing a new `crash/2` signature that matches `Process.exit/2` conventions.

**Key Changes:**
- Removed `crash!/1` function (the `!` suffix should be reserved for functions that raise exceptions)
- New signature: `crash(process, type \\ :shutdown)` with process as the first argument
- Enables natural piping: `Process.whereis(:name) |> LetItCrash.crash(:kill)`
- Updated all tests and documentation to reflect the new API
- Added piping tests to validate the new functionality

## Type of Change

Mark the type of change this PR represents:

- [ ] 🐛 Bug fix (change that fixes an issue)
- [ ] ✨ New feature (change that adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation (documentation-only changes)
- [x] 🧹 Refactoring (code changes that neither fix bugs nor add features)
- [ ] ⚡ Performance (changes that improve performance)
- [x] 🧪 Tests (adding or correcting tests)

## How to Test

Run the test suite to verify all functionality works correctly with the new API:

```bash
# Run all tests
mix test

# Run with coverage
mix test --cover

# Verify code quality
mix credo --strict

# Check formatting
mix format --check-formatted

# Generate documentation
mix docs
```

**Testing the new API:**

```elixir
# Default :shutdown signal
{:ok, pid} = Agent.start_link(fn -> 0 end)
LetItCrash.crash(pid)

# Explicit :kill signal
{:ok, pid} = MyTrapExitServer.start_link()
LetItCrash.crash(pid, :kill)

# Piping support (new feature)
Process.whereis(:my_process)
|> LetItCrash.crash(:kill)
```

## Checklist

- [x] My code follows the project's style guide
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (22 tests, 0 failures)
- [x] I have updated the CHANGELOG.md (if applicable)

## Migration Guide

For users upgrading from previous versions:

**Before (v0.2.0):**
```elixir
LetItCrash.crash!(pid)           # Old API
LetItCrash.crash!(:process_name) # Old API
```

**After (v0.3.0):**
```elixir
LetItCrash.crash(pid, :kill)           # New API
LetItCrash.crash(:process_name, :kill) # New API

# Bonus: Now supports piping!
Process.whereis(:name) |> LetItCrash.crash(:kill)
```

## Related Issues

Addresses best practices alignment with Elixir conventions:
- Removes misuse of `!` suffix (should only be used for exception-raising functions)
- Follows `Process.exit/2` convention for consistency
- Enables idiomatic pipe operator usage

## Rationale

**Why this change?**

1. **Elixir Conventions**: In Elixir, the `!` suffix is conventionally reserved for functions that raise exceptions (e.g., `File.read!`, `Enum.fetch!`). Our `crash!/1` was using `:kill` signal, not raising exceptions, which violates this convention.

2. **Consistency with stdlib**: `Process.exit/2` uses the signature `exit(pid, reason)` with the process first. Our new API matches this pattern.

3. **Piping Support**: By placing the process as the first argument, we enable natural piping:
   ```elixir
   Process.whereis(:worker)
   |> LetItCrash.crash(:kill)
   ```

4. **Better Developer Experience**: More intuitive API that aligns with Elixir's "principle of least surprise."

## Test Results

```
Running ExUnit with seed: 967937, max_cases: 24

......................
Finished in 2.0 seconds (0.00s async, 2.0s sync)
22 tests, 0 failures

Credo: 0 issues found
Format: All files formatted correctly
```

## Documentation Updates

- [x] Updated `README.md` with new API examples and piping usage
- [x] Updated `CHANGELOG.md` with v0.3.0 breaking changes section
- [x] Updated module documentation (`@moduledoc`)
- [x] Updated function documentation (`@doc`)
- [x] Added piping examples to documentation
- [x] All documentation in English for international audience

## Additional Notes

This is a **breaking change** that improves the library's API design. Users will need to update their code when upgrading to v0.3.0, but the migration is straightforward (see Migration Guide above).

The change maintains all existing functionality while making the API more idiomatic and easier to use with Elixir's pipe operator.