### PR TITLE
Chore/add wait for process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-01-19
+
+### Added
+- **`wait_for_process/2` function** - Waits for a registered process to exist and be alive
+  - Useful in test setup when ensuring a process is available before interacting with it
+  - Configurable `:timeout` (default: 1000ms) and `:interval` (default: 50ms) options
+  - Returns `:ok` when process is found, `{:error, :timeout}` otherwise
+  - Particularly helpful after starting supervisors or during async initialization
+
 ## [0.3.0] - 2025-10-21
 
 ### Changed (Breaking)
@@ -86,6 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Issue and PR templates for community contributions
 - Comprehensive test coverage with realistic usage examples
 
+[0.4.0]: https://github.com/volcov/let_it_crash/releases/tag/v0.4.0
 [0.3.0]: https://github.com/volcov/let_it_crash/releases/tag/v0.3.0
 [0.2.0]: https://github.com/volcov/let_it_crash/releases/tag/v0.2.0
 [0.1.0]: https://github.com/volcov/let_it_crash/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -141,6 +141,28 @@ test "coordinator recovers from forced crash" do
 end
 ```
 
+### `wait_for_process/1,2`
+Waits for a registered process to exist and be alive. Useful in test setup when you need to ensure a process is available before interacting with it.
+
+```elixir
+# Basic usage - waits up to 1000ms (default)
+:ok = LetItCrash.wait_for_process(:my_worker)
+
+# With custom timeout for slow-starting processes
+:ok = LetItCrash.wait_for_process(:heavy_worker, timeout: 5000)
+
+# With custom polling interval
+:ok = LetItCrash.wait_for_process(:worker, timeout: 2000, interval: 100)
+```
+
+**Options:**
+- `:timeout` - Maximum wait time (default: 1000ms)
+- `:interval` - Polling interval (default: 50ms)
+
+**Returns:**
+- `:ok` - Process exists and is alive
+- `{:error, :timeout}` - Process did not appear within timeout
+
 ### `recovered?/1,2,3`
 Checks if a registered process has recovered after a crash. Multiple signatures available:
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule LetItCrash.MixProject do
   use Mix.Project
 
-  @version "0.3.0"
+  @version "0.4.0"
   @source_url "https://github.com/volcov/let_it_crash"
 
   def project do


### PR DESCRIPTION
# Pull Request

## Description

Add wait_for_process/2 helper function that waits for a registered process to exist and be alive. This is useful in test setup when you need to ensure a process is available before interacting with it, particularly after starting supervisors or during async initialization.

## Type of Change

Mark the type of change this PR represents:

- [ ] 🐛 Bug fix (change that fixes an issue)
- [x] ✨ New feature (change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation (documentation-only changes)
- [ ] 🧹 Refactoring (code changes that neither fix bugs nor add features)
- [ ] ⚡ Performance (changes that improve performance)
- [ ] 🧪 Tests (adding or correcting tests)

## How to Test

Describe how to review and test your changes:

```bash
mix test test/let_it_crash_test.exs --only describe:"wait_for_process/2"
```

## Checklist

- [x] My code follows the project's style guide
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md (if applicable)

## Related Issues

## Screenshots (if applicable)

## Additional Notes
